### PR TITLE
Add seeded deck generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,24 @@ pnpm install
 pnpm lint --fix
 pnpm test
 ```
+
+## Playing Locally
+
+Start the NestJS server and the Vite dev server in separate terminals:
+
+```bash
+pnpm --filter server start:dev
+pnpm --filter web dev
+```
+
+Open <http://localhost:5173> in your browser to play with the front-end. The
+back end listens on <http://localhost:3000>.
+
+## Running Tests
+
+All packages share the same test command:
+
+```bash
+pnpm lint --fix
+pnpm test
+```

--- a/engine/src/deck.ts
+++ b/engine/src/deck.ts
@@ -1,0 +1,46 @@
+export type Card = string;
+
+function seedToInt(seed: number | string): number {
+  if (typeof seed === 'number') return seed;
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(31, h) + seed.charCodeAt(i);
+    h |= 0;
+  }
+  return h >>> 0;
+}
+
+function mulberry32(a: number): () => number {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(array: T[], seed: number | string): T[] {
+  const random = mulberry32(seedToInt(seed));
+  const result = array.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+export function createDeck(seed: number | string): Card[] {
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+  const suits = ['♠', '♥', '♦'];
+  const cards: Card[] = [];
+  for (let d = 0; d < 2; d++) {
+    for (const suit of suits) {
+      for (const rank of ranks) {
+        cards.push(`${rank}${suit}`);
+      }
+    }
+    cards.push('SJ');
+  }
+  cards.push('BJ');
+  return shuffle(cards, seed);
+}

--- a/engine/tsconfig.json
+++ b/engine/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -2,19 +2,22 @@
   "name": "codex-guandan-online",
   "private": true,
   "version": "0.0.0",
-  "workspaces": ["web", "server"],
+  "workspaces": [
+    "web",
+    "server"
+  ],
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "format": "prettier --write .",
     "test": "vitest run && pnpm -r --parallel test"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "@typescript-eslint/parser": "^6.7.0",
     "prettier": "^3.0.0",
     "vitest": "^0.34.0"
   }

--- a/test/deck.test.ts
+++ b/test/deck.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { createDeck } from '@engine/deck';
+
+describe('deck', () => {
+  it('generates 81 cards with no clubs and one big joker', () => {
+    const deck = createDeck(42);
+    expect(deck).toHaveLength(81);
+    for (const card of deck) {
+      expect(card.includes('♣')).toBe(false);
+    }
+    const bigJokers = deck.filter((c) => c === 'BJ');
+    expect(bigJokers).toHaveLength(1);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@engine/*": ["engine/src/*"]
+    }
   },
-  "include": ["web", "server"]
+  "include": ["web", "server", "engine"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@engine': resolve(__dirname, 'engine/src'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- implement deck generator with deterministic shuffle
- configure path aliases for `@engine`
- add vitest alias resolution
- expand README with local run and test instructions
- test deck generation

## Testing
- `pnpm lint --fix`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687def81685c8331822dfb86684f2c78