### PR TITLE
Implement card engine state machine

### DIFF
--- a/engine/src/dealGame.ts
+++ b/engine/src/dealGame.ts
@@ -1,0 +1,16 @@
+import { createDeck, Card } from './deck';
+
+export interface DealResult {
+  players: Card[][]; // 3 players
+  bottom: Card[]; // 6 cards
+}
+
+export function dealGame(seed: number | string): DealResult {
+  const deck = createDeck(seed);
+  const players: Card[][] = [[], [], []];
+  for (let i = 0; i < 75; i++) {
+    players[i % 3].push(deck[i]);
+  }
+  const bottom = deck.slice(75);
+  return { players, bottom };
+}

--- a/engine/src/rules.ts
+++ b/engine/src/rules.ts
@@ -1,0 +1,119 @@
+import type { Card } from './deck';
+
+export const RANK_ORDER = [
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'J',
+  'Q',
+  'K',
+  'A',
+  '2',
+  'SJ',
+  'BJ',
+] as const;
+
+export type Rank = (typeof RANK_ORDER)[number];
+
+function rankValue(rank: Rank): number {
+  return RANK_ORDER.indexOf(rank);
+}
+
+export function cardRank(card: Card): Rank {
+  if (card === 'SJ' || card === 'BJ') return card as Rank;
+  // card like 'A♠'
+  return card.replace(/[♠♥♦]/, '') as Rank;
+}
+
+export interface Single {
+  type: 'single';
+  rank: Rank;
+  cards: [Card];
+}
+
+export interface Pair {
+  type: 'pair';
+  rank: Rank;
+  cards: [Card, Card];
+}
+
+export interface Bomb {
+  type: 'bomb';
+  rank: Rank | 'JOKER';
+  cards: Card[]; // length 4-6 or 3 jokers
+}
+
+export type Play = Single | Pair | Bomb;
+
+export function isSingle(cards: Card[]): cards is [Card] {
+  return cards.length === 1;
+}
+
+export function isPair(cards: Card[]): cards is [Card, Card] {
+  return cards.length === 2 && cardRank(cards[0]) === cardRank(cards[1]);
+}
+
+function isRegularBomb(cards: Card[]): boolean {
+  if (cards.length < 4 || cards.length > 6) return false;
+  const r = cardRank(cards[0]);
+  return cards.every((c) => cardRank(c) === r);
+}
+
+function isJokerBomb(cards: Card[]): boolean {
+  if (cards.length !== 3) return false;
+  return cards.every((c) => c === 'SJ' || c === 'BJ');
+}
+
+export function getPlay(cards: Card[]): Play | null {
+  const sorted = cards.slice();
+  if (isSingle(sorted)) {
+    return { type: 'single', rank: cardRank(sorted[0]), cards: sorted };
+  }
+  if (isPair(sorted)) {
+    return { type: 'pair', rank: cardRank(sorted[0]), cards: sorted };
+  }
+  if (isJokerBomb(sorted)) {
+    return { type: 'bomb', rank: 'JOKER', cards: sorted };
+  }
+  if (isRegularBomb(sorted)) {
+    return { type: 'bomb', rank: cardRank(sorted[0]), cards: sorted };
+  }
+  return null;
+}
+
+export function compareSingle(a: Single, b: Single): number {
+  return rankValue(b.rank) - rankValue(a.rank);
+}
+
+export function comparePair(a: Pair, b: Pair): number {
+  return rankValue(b.rank) - rankValue(a.rank);
+}
+
+function bombStrength(b: Bomb): number {
+  if (b.rank === 'JOKER') return 100;
+  return b.cards.length * 10 + rankValue(b.rank);
+}
+
+export function compareBomb(a: Bomb, b: Bomb): number {
+  return bombStrength(b) - bombStrength(a);
+}
+
+export function beats(prev: Play, next: Play): boolean {
+  if (next.type === 'bomb' && prev.type !== 'bomb') return true;
+  if (prev.type === 'bomb' && next.type !== 'bomb') return false;
+  if (prev.type === 'single' && next.type === 'single') {
+    return compareSingle(prev, next) > 0;
+  }
+  if (prev.type === 'pair' && next.type === 'pair') {
+    return comparePair(prev, next) > 0;
+  }
+  if (prev.type === 'bomb' && next.type === 'bomb') {
+    return compareBomb(prev, next) > 0;
+  }
+  return false;
+}

--- a/engine/src/stateMachine.ts
+++ b/engine/src/stateMachine.ts
@@ -1,0 +1,66 @@
+import type { Card } from './deck';
+import { dealGame } from './dealGame';
+import { getPlay, beats, Play } from './rules';
+
+export interface GameState {
+  hands: Card[][];
+  bottom: Card[];
+  turn: number; // index of current player
+  lastPlay?: { player: number; play: Play };
+  finished: boolean;
+  payouts: number[]; // length 3
+}
+
+export function initGame(seed: number | string): GameState {
+  const { players, bottom } = dealGame(seed);
+  return {
+    hands: players,
+    bottom,
+    turn: 0,
+    finished: false,
+    payouts: [0, 0, 0],
+  };
+}
+
+export interface Move {
+  cards: Card[]; // empty array means pass
+}
+
+function removeCards(hand: Card[], cards: Card[]): Card[] {
+  const copy = hand.slice();
+  for (const c of cards) {
+    const idx = copy.indexOf(c);
+    if (idx === -1) throw new Error('Card not in hand');
+    copy.splice(idx, 1);
+  }
+  return copy;
+}
+
+export function play(state: GameState, move: Move): GameState {
+  if (state.finished) return state;
+  const hand = state.hands[state.turn];
+  if (move.cards.length === 0) {
+    return {
+      ...state,
+      turn: (state.turn + 1) % 3,
+    };
+  }
+  const playObj = getPlay(move.cards);
+  if (!playObj) throw new Error('Illegal play');
+  if (state.lastPlay && !beats(state.lastPlay.play, playObj)) {
+    throw new Error('Play does not beat previous');
+  }
+  const newHand = removeCards(hand, move.cards);
+  const hands = state.hands.slice();
+  hands[state.turn] = newHand;
+  const finished = newHand.length === 0;
+  const payouts = finished ? hands.map((_, i) => (i === state.turn ? 1 : -1)) : state.payouts;
+  return {
+    hands,
+    bottom: state.bottom,
+    turn: finished ? state.turn : (state.turn + 1) % 3,
+    lastPlay: finished ? undefined : { player: state.turn, play: playObj },
+    finished,
+    payouts,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.0.0",
-    "vitest": "^0.34.0"
+    "vitest": "^0.34.0",
+    "fast-check": "^3.10.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.2(eslint@8.57.1)
+      fast-check:
+        specifier: ^3.10.0
+        version: 3.23.2
       prettier:
         specifier: ^3.0.0
         version: 3.6.2
@@ -1654,6 +1657,10 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5387,6 +5394,10 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 

--- a/test/dealGame.test.ts
+++ b/test/dealGame.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { dealGame } from '@engine/dealGame';
+
+describe('dealGame', () => {
+  it('deals 25 cards each and 6 bottom', () => {
+    const { players, bottom } = dealGame(42);
+    expect(players).toHaveLength(3);
+    players.forEach((p) => expect(p).toHaveLength(25));
+    expect(bottom).toHaveLength(6);
+  });
+
+  it('is deterministic with same seed', () => {
+    const a = dealGame('seed');
+    const b = dealGame('seed');
+    expect(a).toEqual(b);
+  });
+});

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { getPlay, beats } from '@engine/rules';
+
+const singleA = ['A♠'];
+const single2 = ['2♠'];
+const pair55 = ['5♠', '5♥'];
+const pair66 = ['6♠', '6♥'];
+const bomb4 = ['7♠', '7♥', '7♦', '7♠'];
+const bomb5 = ['8♠', '8♥', '8♦', '8♠', '8♥'];
+const jokerBomb = ['SJ', 'SJ', 'BJ'];
+
+describe('rules', () => {
+  it('parses legal plays', () => {
+    expect(getPlay(singleA)?.type).toBe('single');
+    expect(getPlay(pair55)?.type).toBe('pair');
+    expect(getPlay(bomb4)?.type).toBe('bomb');
+    expect(getPlay(jokerBomb)?.type).toBe('bomb');
+  });
+
+  it('rejects illegal plays', () => {
+    expect(getPlay(['A♠', 'A♥', 'A♦'])).toBeNull();
+    expect(getPlay(['SJ', 'BJ'])).toBeNull();
+  });
+
+  it('compare plays', () => {
+    const pA = getPlay(singleA)!;
+    const p2 = getPlay(single2)!;
+    expect(beats(pA, p2)).toBe(true);
+    const pair5 = getPlay(pair55)!;
+    const pair6 = getPlay(pair66)!;
+    expect(beats(pair5, pair6)).toBe(true);
+    const b4 = getPlay(bomb4)!;
+    const b5 = getPlay(bomb5)!;
+    expect(beats(pair6, b4)).toBe(true);
+    expect(beats(b4, b5)).toBe(true);
+    const jb = getPlay(jokerBomb)!;
+    expect(beats(b5, jb)).toBe(true);
+    expect(beats(b4, jb)).toBe(true);
+    expect(beats(jb, b5)).toBe(false);
+  });
+});

--- a/test/stateMachine.test.ts
+++ b/test/stateMachine.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { play } from '@engine/stateMachine';
+import type { GameState } from '@engine/stateMachine';
+
+describe('stateMachine', () => {
+  it('game ends when someone empties hand', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('A♠', '2♠', 'SJ'), (card) => {
+        const state: GameState = {
+          hands: [[card], ['X'], ['Y']],
+          bottom: [],
+          turn: 0,
+          finished: false,
+          payouts: [0, 0, 0],
+        };
+        const next = play(state, { cards: [card] });
+        expect(next.finished).toBe(true);
+        expect(next.payouts[0]).toBe(1);
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement rules for singles, pairs and bombs
- add deterministic `dealGame` for 3-player deal
- create game state machine with play validation
- test rules, dealing and end-of-game logic

## Testing
- `pnpm lint --fix`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687df5d35528833192092a140eb52916