### PR TITLE
Fix auto start on third join

### DIFF
--- a/server/src/gateway/game.gateway.ts
+++ b/server/src/gateway/game.gateway.ts
@@ -55,7 +55,13 @@ export class GameGateway implements OnGatewayConnection {
     const dto = this.parse(joinRoomSchema, payload);
     client.join(dto.roomId);
     await this.rooms.joinRoom(dto.roomId, client.id);
-    const state = await this.rooms.getState(dto.roomId);
+    const count = await this.rooms.getPlayerCount(dto.roomId);
+    let state = await this.rooms.getState(dto.roomId);
+    if (!state && count === 3) {
+      state = await this.rooms.startGame(dto.roomId, Date.now());
+      this.server.to(dto.roomId).emit('state', state);
+      return;
+    }
     if (state) {
       client.emit('state', state);
     }

--- a/server/src/room.service.ts
+++ b/server/src/room.service.ts
@@ -17,6 +17,10 @@ export class RoomService {
     await this.redis.expire(this.playersKey(roomId), 60 * 60 * 24);
   }
 
+  async getPlayerCount(roomId: string): Promise<number> {
+    return this.redis.scard(this.playersKey(roomId));
+  }
+
   async startGame(roomId: string, seed: number | string): Promise<GameState> {
     const state = initGame(seed);
     await this.redis.set(this.key(roomId), JSON.stringify(state), 'EX', 60 * 60 * 24);


### PR DESCRIPTION
## Summary
- start games server-side once the third player joins
- expose `getPlayerCount` in `RoomService`

## Testing
- `pnpm lint --fix`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687e23563c048331bfa259c93020b1f8